### PR TITLE
Add `cheshire` dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
             :year 2015}
   :dependencies [[org.yaml/snakeyaml "1.17"]
                  [rewrite-clj "0.5.0"
-                  :exclusions [org.clojure/clojure]]]
+                  :exclusions [org.clojure/clojure]]
+                 [cheshire "5.8.0"]]
   :eval-in :leiningen
   :pedantic? :abort)


### PR DESCRIPTION
`cheshire` was removed from Leiningen's own `project.clj`, but `leiningen.license.list` depends on it.